### PR TITLE
Add tracks_source to gliding.tracks

### DIFF
--- a/lrv/database/migrations/2019_03_06_064253_add_tracking_source_to_tracks.php
+++ b/lrv/database/migrations/2019_03_06_064253_add_tracking_source_to_tracks.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class AddTrackingSourceToTracks extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('tracks', function($table) {
+            DB::statement('SET SQL_MODE = "ALLOW_INVALID_DATES";');
+            DB::statement('ALTER TABLE tracks ALTER COLUMN `point_time` DROP DEFAULT');
+            DB::statement('ALTER TABLE tracks CHANGE COLUMN `point_time` `point_time` DATETIME NOT NULL');
+            $table->string('tracks_source', 16)->nullable(true)->default(null);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('tracks', function($table) {
+            $table->dropColumn('tracks_source');
+            DB::statement('ALTER TABLE tracks CHANGE COLUMN `point_time` `point_time` TIMESTAMP NOT NULL');
+        });
+    }
+}


### PR DESCRIPTION
Create a new migration file:
```
gliding-ops cdan$ cd lrv/
gliding-ops cdan$ php artisan make:migration add_tracking_source_to_tracks
Created Migration: 2019_03_06_064253_add_tracking_source_to_tracks
```
This adds the appropriate timestamp to the migration file name so that laravel knows the order in which to apply migrations.

Edit the new migration file and add the new column in the up()/down() function. The Schema builder API I think is straight forward. however, the documentation is here https://laravel.com/docs/5.8/migrations#creating-tables

You can check if there are any pending migrations with:
`gliding-ops cdan$ php artisan migrate:status`

Once the newmigration is in place you need to apply it:
`gliding-ops cdan$ php artisan migrate`

If you need to rollback the last migration
`gliding-ops cdan$ php artisan migrate:rollback`